### PR TITLE
Set cols to 5 to include Non-combustion

### DIFF
--- a/EDGAR CO2 Emissions.ipynb
+++ b/EDGAR CO2 Emissions.ipynb
@@ -263,7 +263,7 @@
     "for code in [\"WORLD\", \"USA\", \"CHN\", \"EU28\"]:\n",
     "    grouped = df.loc[code].reset_index().set_index(\"Year\").groupby(\"Sector\")[\"Emissions\"]\n",
     "\n",
-    "    fig, axes = plt.subplots(nrows=1, ncols=4, figsize=(12,4), sharey=True)\n",
+    "    fig, axes = plt.subplots(nrows=1, ncols=5, figsize=(12,4), sharey=True)\n",
     "    try:\n",
     "        name = to_name(code)\n",
     "    except KeyError:\n",


### PR DESCRIPTION
Number of charts to plot should be 5 if we want to plot a chart for each of the 5 sectors. Before this change, the charts for Non-combustion were missing.

**Before:**
![image](https://user-images.githubusercontent.com/961528/62814328-13554a80-bb08-11e9-93cf-a2cc72be2d1a.png)

**After:**
![image](https://user-images.githubusercontent.com/961528/62814330-1819fe80-bb08-11e9-89e0-50e7bfe14a34.png)
